### PR TITLE
Monkeypatch urllib import for python2 compat

### DIFF
--- a/rescale/client.py
+++ b/rescale/client.py
@@ -1,10 +1,19 @@
-import urllib.parse
 import json
 import logging
 import time
 import os
 
 import requests
+
+try:
+    # python 3 required
+    import urllib.parse
+except ImportError:
+    # monkeypatch for python 2 compat
+    import urllib
+    import urlparse
+    urlparse.urlencode = urllib.urlencode
+    urllib.parse = urlparse
 
 
 class RescaleConnect(object):
@@ -40,7 +49,7 @@ class RescaleConnect(object):
     def _request(self, method, relative_url,
                  **kwargs):
         headers = {'Authorization': 'Token ' + self.api_key}
-        if not 'files' in kwargs:
+        if 'files' not in kwargs:
             headers['Content-Type'] = 'application/json'
 
         response = requests.request(method,


### PR DESCRIPTION
`urllib.parse` is not available in python2; this patch allows using the sdk from python2 as-is